### PR TITLE
Fix issue #1

### DIFF
--- a/src/parser.py
+++ b/src/parser.py
@@ -40,14 +40,13 @@ class XmlParser:
 
     def ratios(self):
         self.diff_ratios = dict()
-        # TODO: this is terribly slow. Add threading.
         for i, path in enumerate(self.paths):
             with open(path, 'r') as xml:
-                for j in range(i+1, len(self.paths)):
-                    path2 = self.paths[j]
+                xml.seek(0)
+                for path2 in self.paths[i+1:]:
                     with open(path2, 'r') as xml2:
                         seq_match = difflib.SequenceMatcher(lambda x: x in " \t", xml.read(), xml2.read())
-                        ratio = seq_match.ratio()
+                        ratio = seq_match.quick_ratio()
                         self.diff_ratios[path, path2] = ratio
 
         return self.diff_ratios

--- a/src/parser.py
+++ b/src/parser.py
@@ -42,8 +42,8 @@ class XmlParser:
         self.diff_ratios = dict()
         for i, path in enumerate(self.paths):
             with open(path, 'r') as xml:
-                xml.seek(0)
                 for path2 in self.paths[i+1:]:
+                    xml.seek(0)
                     with open(path2, 'r') as xml2:
                         seq_match = difflib.SequenceMatcher(lambda x: x in " \t", xml.read(), xml2.read())
                         ratio = seq_match.quick_ratio()


### PR DESCRIPTION
This fix for issue #1 ensures that all files are correctly receiving a ratio of similarity.

The issue was caused by the first xml file being fully read into memory fully and then trying to be read into memory again for continuous iterations of the inner for loop. The file's tell was the length of the file, meaning that `xml.read()` was returning nothing. This is why we were seeing similarity ratios of 0.00%.

Also, this PR has some small refactoring.